### PR TITLE
Mask AP password

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -298,7 +298,7 @@ std::string Item::as_json()
     if (!cache_json.v.empty())
         return cache_json.v;
 
-    const bool mask = is_pincode();
+    const bool mask = is_pincode() || is_ap_password();
     nlohmann::json j { {"value", value.value.as_json_value(mask)} };
 
     if (value.min)
@@ -394,6 +394,11 @@ const std::string &Item::get_service_name() const
 bool Item::should_be_retained() const
 {
     return short_service_name.service_type == "system" && path.get() == "/Serial";
+}
+
+bool Item::is_ap_password() const
+{
+    return short_service_name.service_type == "settings" && path.get() == "/Settings/Services/AccessPointPassword";
 }
 
 bool Item::is_pincode() const

--- a/src/types.h
+++ b/src/types.h
@@ -64,6 +64,7 @@ public:
     const std::string &get_path() const;
     const std::string &get_service_name() const;
     bool should_be_retained() const;
+    bool is_ap_password() const;
     bool is_pincode() const;
     bool is_vrm_portal_mode() const;
 };

--- a/src/vevariant.cpp
+++ b/src/vevariant.cpp
@@ -381,9 +381,7 @@ nlohmann::json VeVariant::as_json_value(bool mask) const
     {
         if (mask)
         {
-            std::string val = str;
-            std::transform(val.begin(), val.end(), val.begin(), [](char c) {return '*';});
-            return val;
+            return "******";
         }
         return str;
     }


### PR DESCRIPTION
Just like the BLE pincode, the AP password is now also masked. The mask has been changed from replacing every character with a * to just returning "******". This ways, there is no hint in how long the password is.